### PR TITLE
updating to visual framework v1.3

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,11 +17,11 @@
 -->
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <!-- Your custom JavaScript file scan go here... change names accordingly -->
-<script defer="defer" src="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/js/script.js"></script>
+<script defer="defer" src="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/script.js"></script>
 
 <!-- The Foundation theme JavaScript -->
-<script src="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/libraries/foundation-6/js/foundation.js"></script>
-<script src="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/js/foundationExtendEBI.js"></script>
+<script src="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/libraries/foundation-6/js/foundation.js"></script>
+<script src="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/foundationExtendEBI.js"></script>
 <script type="text/JavaScript">$(document).foundation();</script>
 <script type="text/JavaScript">$(document).foundationExtendEBI();</script>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,21 +20,20 @@
 
   <!-- If you have custom icon, replace these as appropriate.
        You can generate them at realfavicongenerator.net -->
-  <link rel="icon" type="image/x-icon" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/images/logos/EMBL-EBI/favicons/favicon.ico" />
-  <link rel="icon" type="image/png" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/images/logos/EMBL-EBI/favicons/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="192×192" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/images/logos/EMBL-EBI/favicons/android-chrome-192x192.png" /> <!-- Android (192px) -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/images/logos/EMBL-EBI/favicons/apple-icon-114x114.png"> <!-- For iPhone 4 Retina display (114px) -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/images/logos/EMBL-EBI/favicons/apple-icon-72x72.png"> <!-- For iPad (72px) -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/images/logos/EMBL-EBI/favicons/apple-icon-144x144.png"> <!-- For iPad retinat (144px) -->
-  <link rel="apple-touch-icon-precomposed" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/images/logos/EMBL-EBI/favicons/apple-icon-57x57.png"> <!-- For iPhone (57px) -->
-  <link rel="mask-icon" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/images/logos/EMBL-EBI/favicons/safari-pinned-tab.svg" color="#ffffff"> <!-- Safari icon for pinned tab -->
+  <link rel="icon" type="image/x-icon" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/favicons/favicon.ico" />
+  <link rel="icon" type="image/png" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/favicons/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="192×192" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/favicons/android-chrome-192x192.png" /> <!-- Android (192px) -->
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/favicons/apple-icon-114x114.png"> <!-- For iPhone 4 Retina display (114px) -->
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/favicons/apple-icon-72x72.png"> <!-- For iPad (72px) -->
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/favicons/apple-icon-144x144.png"> <!-- For iPad retinat (144px) -->
+  <link rel="apple-touch-icon-precomposed" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/favicons/apple-icon-57x57.png"> <!-- For iPhone (57px) -->
+  <link rel="mask-icon" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/favicons/safari-pinned-tab.svg" color="#ffffff"> <!-- Safari icon for pinned tab -->
   <meta name="msapplication-TileColor" content="#2b5797"> <!-- MS Icons -->
-  <meta name="msapplication-TileImage" content="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/images/logos/EMBL-EBI/favicons/mstile-144x144.png">
+  <meta name="msapplication-TileImage" content="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/images/logos/EMBL-EBI/favicons/mstile-144x144.png">
 
   <!-- CSS: implied media=all -->
   <!-- CSS concatenated and minified via ant build script-->
-  <link rel="stylesheet" href="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/libraries/foundation-6/css/foundation.css" type="text/css" media="all">
-  <link rel="stylesheet" href="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/css/ebi-global.css" type="text/css" media="all">
+  <link rel="stylesheet" href="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/css/ebi-global.css" type="text/css" media="all">
   <link rel="stylesheet" href="//ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.2/fonts.css" type="text/css" media="all">
 
   <!-- Use this CSS file for any custom styling -->
@@ -54,7 +53,7 @@
 
     <!-- you can replace this with theme-[projectname].css. See http://www.ebi.ac.uk/web/style/colour for details of how to do this -->
   <!-- also inform ES so we can host your colour palette file -->
-  <link rel="stylesheet" href="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/css/theme-embl-petrol.css" type="text/css" media="all">
+  <link rel="stylesheet" href="//ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/css/theme-embl-petrol.css" type="text/css" media="all">
 
   <!-- for production the above can be replaced with -->
   <!--

--- a/_includes/local_masthead.html
+++ b/_includes/local_masthead.html
@@ -8,26 +8,5 @@
   </div>
 
   <header id="masthead-black-bar" class="clearfix masthead-black-bar">
-    <nav class="row">
-      <ul id="global-nav" class="menu">
-        <!-- set active class as appropriate -->
-        <li class="home-mobile"><a href="//www.ebi.ac.uk"></a></li>
-        <li class="home active"><a href="//www.ebi.ac.uk">EMBL-EBI</a></li>
-        <li class="services"><a href="//www.ebi.ac.uk/services">Services</a></li>
-        <li class="research"><a href="//www.ebi.ac.uk/research">Research</a></li>
-        <li class="training"><a href="//www.ebi.ac.uk/training">Training</a></li>
-        <li class="about"><a href="//www.ebi.ac.uk/about">About us</a></li>
-        <li class="search">
-          <a href="#" data-toggle="search-global-dropdown"><span class="show-for-small-only">Search</span></a>
-          <div id="search-global-dropdown" class="dropdown-pane" data-dropdown data-options="closeOnClick:true;">
-          <!-- The dropdown menu will be programatically added by script.js -->
-          </div>
-        </li>
-        <li class="float-right show-for-medium embl-selector">
-          <button class="button float-right" type="button" data-toggle="embl-dropdown">Hinxton</button>
-          <!-- The dropdown menu will be programatically added by script.js -->
-        </li>
-      </ul>
-    </nav>
   </header>
   


### PR DESCRIPTION
Updated following the https://github.com/ebiwd/EBI-Framework readme, e.g.

- Update your v1.2 asset references to v1.3
- Remove the reference to foundation.min.css or foundation.css (this is now included in ebi-global.css)
- Remove the HTML markup inside your div#masthead-black-bar. This will automatically be inserted by script.js.