### PR TITLE
 Making site moree domain independent for dev/live urls to work 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,20 +13,29 @@ permalink: pretty
 # custom_js:
 # - "{{site.baseurl}}/static/js/YOUR-CSS-COMPONENTS.js"
 # - "{{site.baseurl}}/static/js/ANOTHER-CSS-COMPONENTS.js"
-ga_code: 'UA-XXXXX-X'
+ga_code: "UA-XXXXX-X"
 
 # root repo for this project
-repo:        "https://github.com/ebiwd/EBI-Pattern-library"
-source:      .
+repo: "https://github.com/ebiwd/EBI-Pattern-library"
+source: .
 destination: ./_site
-exclude:     [node_modules, .sass-cache, gulpfile.js, package.json, HOWTO.md, docker-compose.yml, .gitlab-ci.yml]
+exclude:
+  [
+    node_modules,
+    .sass-cache,
+    gulpfile.js,
+    package.json,
+    HOWTO.md,
+    docker-compose.yml,
+    .gitlab-ci.yml,
+  ]
 #plugins:     ./_plugins
-future:      false
-lsi:         false
-markdown:    kramdown
+future: false
+lsi: false
+markdown: kramdown
 highlighter: rouge
-
 # Allow redirects
 # https://help.github.com/articles/redirects-on-github-pages/
-plugins:
-  - jekyll-redirect-from
+# *NB - This plugin causes problems when building the site locally. Disabling by default
+#plugins:
+#  - jekyll-redirect-from

--- a/_includes/navigation_list.html
+++ b/_includes/navigation_list.html
@@ -1,11 +1,11 @@
-{% for node in navigation_list %}
-  {% if group == null or group == node.group %}
-    {% if page.url == node.url %}
-      <li class="active"><a href="{{ site.domain }}{{ site.baseurl }}{{node.url}}" class="active">{{node.title}}</a></li>
-    {% else %}
-      <li><a href="{{ site.domain }}{{ site.baseurl }}{{node.url}}">{{node.title}}</a></li>
-    {% endif %}
-  {% endif %}
-{% endfor %}
-{% assign pages_list = nil %}
-{% assign group = nil %}
+{% for node in navigation_list %} {% if group == null or group == node.group %}
+{% if page.url == node.url %}
+<li class="active">
+  <a href="{{ site.baseurl }}{{ node.url }}" class="active">{{ node.title }}</a>
+</li>
+{% else %}
+<li>
+  <a href="{{ site.baseurl }}{{ node.url }}">{{ node.title }}</a>
+</li>
+{% endif %} {% endif %} {% endfor %} {% assign pages_list = nil %} {% assign
+group = nil %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,31 +1,52 @@
 <!DOCTYPE html>
 <html lang="en">
   {% include head.html %}
-  <body class="level2"><!-- add any of your classes or IDs -->
+  <body class="level2">
+    <!-- add any of your classes or IDs -->
     {% include local_masthead.html %}
     <div id="content" role="main">
       <div data-sticky-container>
-        <div id="masthead" class="masthead" data-sticky data-sticky-on="large" data-top-anchor="main-content-area:top" data-btm-anchor="main-content-area:bottom">
+        <div
+          id="masthead"
+          class="masthead"
+          data-sticky
+          data-sticky-on="large"
+          data-top-anchor="main-content-area:top"
+          data-btm-anchor="main-content-area:bottom"
+        >
           <div class="masthead-inner row">
             <!-- local-title -->
             <div class="columns medium-7" id="local-title">
-              <h1><a href="{{ site.domain }}{{ site.baseurl }}" title="Back to {{ site.title }} homepage">{{ site.title }}</a></h1>
-              <h4>An implementation of <a href="http://github.com/ebiwd/EBI-Framework">the EBI Visual Framework  <i class="icon icon-generic small" data-icon="x"></i></a></h4>
+              <h1>
+                <a
+                  href="{{ site.baseurl }}"
+                  title="Back to {{ site.title }} homepage"
+                  >{{ site.title }}</a
+                >
+              </h1>
+              <h4>
+                An implementation of
+                <a href="http://github.com/ebiwd/EBI-Framework"
+                  >the EBI Visual Framework
+                  <i class="icon icon-generic small" data-icon="x"></i
+                ></a>
+              </h4>
             </div>
             <!-- /local-title -->
             <!-- local-nav -->
             <nav>
-              <ul id="local-nav" class="dropdown menu float-left" data-description="navigational" data-dropdown-menu>
-                {% comment %}
-                We construct the site naviagion by loading a list of the site's pages
-                and filtering to just those with the front matter of:
-                  group: "in_local_navigation"
-                and we order by adding
-                  order: 2 (whatever number)
-                {% endcomment %}
-                {% assign navigation_list = site.pages | sort:"order" %}
-                {% assign group = 'in_local_navigation' %}
-                {% include navigation_list.html %}
+              <ul
+                id="local-nav"
+                class="dropdown menu float-left"
+                data-description="navigational"
+                data-dropdown-menu
+              >
+                {% comment %} We construct the site naviagion by loading a list
+                of the site's pages and filtering to just those with the front
+                matter of: group: "in_local_navigation" and we order by adding
+                order: 2 (whatever number) {% endcomment %} {% assign
+                navigation_list = site.pages | sort:"order" %} {% assign group =
+                'in_local_navigation' %} {% include navigation_list.html %}
               </ul>
               <!-- <ul class="menu dropdown float-right" data-dropdown-menu data-description="functional">
                 <li class="functional"><a href="#"><i class="icon icon-generic" data-icon="d"></i> Share this</a>
@@ -76,17 +97,39 @@
         </nav>
         -->
         <div class="medium-9 columns">
-        {{ content }}
+          {{ content }}
         </div>
         <div class="medium-3 columns sidebar" data-sticky-container>
-          <div class="sticky" data-sticky data-anchor="main-content-area"  data-options="marginTop:4;">
+          <div
+            class="sticky"
+            data-sticky
+            data-anchor="main-content-area"
+            data-options="marginTop:4;"
+          >
             <h4>See also</h4>
-            <p>These resources will help you engage and understand the EBI Framework.</p>
+            <p>
+              These resources will help you engage and understand the EBI
+              Framework.
+            </p>
             <div class="">
               <ul class="menu vertical">
-                <li class=""><a href="//github.com/ebiwd/EBI-Framework">Core framework repository <i class="icon icon-generic" data-icon="x"></i></a></li>
-                <li class=""><a href="//ebiwd.github.io/EBI-Framework">Core framework documentations <i class="icon icon-generic" data-icon="x"></i></a></li>
-                <li class=""><a href="//ebiwd.github.io/EBI-Framework/sample-site/">Sample pages <i class="icon icon-generic" data-icon="x"></i></a></li>
+                <li class="">
+                  <a href="//github.com/ebiwd/EBI-Framework"
+                    >Core framework repository
+                    <i class="icon icon-generic" data-icon="x"></i
+                  ></a>
+                </li>
+                <li class="">
+                  <a href="//ebiwd.github.io/EBI-Framework"
+                    >Core framework documentations
+                    <i class="icon icon-generic" data-icon="x"></i
+                  ></a>
+                </li>
+                <li class="">
+                  <a href="//ebiwd.github.io/EBI-Framework/sample-site/"
+                    >Sample pages <i class="icon icon-generic" data-icon="x"></i
+                  ></a>
+                </li>
               </ul>
             </div>
           </div>
@@ -101,7 +144,8 @@
         </div>
       -->
       <!-- End optional local footer -->
-    </div><!-- /.container -->
+    </div>
+    <!-- /.container -->
     {% include footer.html %}
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,10 +4,15 @@ title: Project home
 group: "in_local_navigation"
 order: 1
 ---
-<div class="blurb">
-	<h2><a href="{{ site.domain }}{{ site.baseurl }}">Hi there</a></h2>
-	<p>Fork this repo to get your Jekyll site up and running on GitHub Pages with the EBI Framework.</p>
 
-	<h3>Recent updates to this project</h3>
-	{% include update_list.html %}
-</div><!-- /.blurb -->
+<div class="blurb">
+  <h2><a href="{{ site.baseurl }}">Hi there</a></h2>
+  <p>
+    Fork this repo to get your Jekyll site up and running on GitHub Pages with
+    the EBI Framework.
+  </p>
+
+  <h3>Recent updates to this project</h3>
+  {% include update_list.html %}
+</div>
+<!-- /.blurb -->


### PR DESCRIPTION
I've removed the use of `{{site.domain}}` everywhere outside of the feeds, so that things like the navigation use relative links instead of hardcoding the domain. 

This was causing confusing when a site is deployed to a dev and live environment (e.g. EBI infrastructure or Netlify), as the navigation on the dev site would often take you to the live.

I've also disabled by default the gitlab redirects module, which causes problems when developing locally. 